### PR TITLE
Fix GetAudio segfault, expose useful APIs

### DIFF
--- a/src/audio.rs
+++ b/src/audio.rs
@@ -102,6 +102,32 @@ set_params!(
     )
 );
 
+impl AudioProperties {
+    pub fn NumSamples(&self) -> i64 {
+        self.audio_properties.NumSamples
+    }
+
+    pub fn SampleRate(&self) -> i32 {
+        self.audio_properties.SampleRate
+    }
+
+    pub fn Channels(&self) -> i32 {
+        self.audio_properties.Channels
+    }
+
+    pub fn SampleFormat(&self) -> i32 {
+        self.audio_properties.SampleFormat
+    }
+
+    pub fn ChannelLayout(&self) -> i64 {
+        self.audio_properties.ChannelLayout
+    }
+
+    pub fn BitsPerSample(&self) -> i32 {
+        self.audio_properties.BitsPerSample
+    }
+}
+
 pub struct AudioSource {
     audio_source: *mut FFMS_AudioSource,
 }

--- a/src/frame.rs
+++ b/src/frame.rs
@@ -57,6 +57,7 @@ impl FrameInfo {
     pub fn KeyFrame(&self) -> usize {
         self.frame_info.KeyFrame as usize
     }
+
     pub(crate) fn create_struct(frame_info: &FFMS_FrameInfo) -> Self {
         FrameInfo {
             frame_info: *frame_info,
@@ -250,6 +251,11 @@ impl Frame {
             data[2].as_ptr(),
             data[3].as_ptr(),
         ];
+    }
+
+    pub fn Data(&self) -> Vec<&u8> {
+        let data = self.frame.Data;
+        unsafe { vec![&*data[0], &*data[1], &*data[2], &*data[3]] }
     }
 
     pub fn set_LineSize(&mut self, linesize: &[usize; 4]) {


### PR DESCRIPTION
Hi, I've been writing a small app using this library but hit a few roadblocks because I couldn't access most of the data I wanted. I would appreciate some feedback on this code, this is my first open-source rust contribution. I completely understand if I went about the wrong way of extending this library's APIs, but I thought I might as well try.

First I added an API to get the `Data` from a `Frame`. It returns a `Vec<*const u8>`. This gives a sort of safe way of accessing the picture planes. It's not totally safe since depending on the format all the data could be in the first plane or it could be split between them, but it's better than nothing.

Secondly I added some APIs for getting some of the data from `AudioProperties`. I feel like it would make more sense to do this for every field using a macro or something, but I haven't touched macros yet so I can't help there. I exposed the audio information that I thought would be useful to most consumers.

Finally I fixed an issue with `GetAudio`. A `Vec` was being created but `FFMS_GetAudio` was segfaulting because `Vec::new` doesn't allocate enough space for all the samples. If we were using a `Vec` normally this would be fine since it would re-allocate to increase it's capacity, but since we're using a pointer we don't have that. Now we use `Vec::with_capacity` to get an appropriately sized `Vec`, and then we reconstruct it with `Vec:::from_raw_parts`.

Sorry about the formatting changes, maybe your `rustfmt` config is different to mine.