### PR TITLE
Fix invalid pointer error on ResampleOptions drop

### DIFF
--- a/src/resample.rs
+++ b/src/resample.rs
@@ -132,8 +132,9 @@ impl ResampleOptions {
 
 impl Drop for ResampleOptions {
     fn drop(&mut self) {
+        let raw_resample = Box::into_raw(Box::new(self.resample));
         unsafe {
-            FFMS_DestroyResampleOptions(&mut self.resample);
+            FFMS_DestroyResampleOptions(raw_resample);
         }
     }
 }


### PR DESCRIPTION
FFMS_AudioSource::CreateResampleOptions gives you a std::unique_ptr, so
they have to be freed differently. The destructor cannot be called with
a normal raw pointer, so we use Box::into_raw to get a wrapped
raw pointer and then it can be correctly destroyed.

Fixes #7