### PR TITLE
Add useful setters to ResampleOptions struct

### DIFF
--- a/src/resample.rs
+++ b/src/resample.rs
@@ -128,6 +128,19 @@ impl ResampleOptions {
     pub(crate) fn as_ptr(&self) -> *const FFMS_ResampleOptions {
         &self.resample
     }
+
+    pub fn set_channel_layout(&mut self, channel_layout: i64) {
+        self.resample.ChannelLayout = channel_layout;
+    }
+
+    pub fn set_sample_format(&mut self, sample_format: &SampleFormat) {
+        self.resample.SampleFormat =
+            SampleFormat::to_sample_format(sample_format);
+    }
+
+    pub fn normalize(&mut self, normalize: bool) {
+        self.resample.Normalize = normalize as i32;
+    }
 }
 
 impl Drop for ResampleOptions {


### PR DESCRIPTION
These are fields I need to change for a project I'm working on, and they seem the most useful out of all the resample options anyway.

Changing the sample rate is not currently supported by ffms2
https://github.com/FFMS/ffms2/blob/master/src/core/audiosource.cpp#L201