### PR TITLE
Allow compilation without pkg-config

### DIFF
--- a/ffms2-sys/Cargo.toml
+++ b/ffms2-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ffms2-sys"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Luni-4 <luni-4@hotmail.it>"]
 description = "FFI bindings to ffms2"
 repository = "https://github.com/rust-av/ffms2-rs"

--- a/ffms2-sys/README.md
+++ b/ffms2-sys/README.md
@@ -1,0 +1,8 @@
+# ffms2-sys
+Automatically generated bindings for FFMS2.
+
+## Building
+This crate requires an installed version of FFMS2 on the build system. If possible, it will use *pkg-config* to locate and link the libraries. Otherwise, it could utilize the environment variables FFMS_INCLUDE_DIR and FFMS_LIB_DIR to locate the required files specified by the user. 
+
+### Building on Windows
+The strategy with the environment variables is especially helpful on Microsoft Windows. In this case, one does not even have to compile the library at all. Instead, developers could refer to the [official releases](https://github.com/FFMS/ffms2/releases). FFMS_INCLUDE_DIR corresponds to the "include" directory while FFMS_LIB_DIR must point to "x64" or "x32", respectively. For the distribution of the final artifact, the corresponding *.dll must be shipped with the executable.

--- a/ffms2-sys/build.rs
+++ b/ffms2-sys/build.rs
@@ -1,6 +1,7 @@
 extern crate bindgen;
 extern crate metadeps;
 
+use env::VarError;
 use std::env;
 use std::fs::File;
 use std::io::Write;
@@ -16,11 +17,51 @@ fn format_write(builder: bindgen::Builder) -> String {
 }
 
 fn main() {
-    let libs = metadeps::probe().unwrap();
-    let headers = libs.get("ffms2").unwrap().include_paths.clone();
+    // Consider 'FFMS_INCLUDE_DIR' and 'FFMS_LIB_DIR', if pkg-config should not be used.
+    let headers = env::var("FFMS_INCLUDE_DIR").map(|value| {
+        // Ensure the include directory is valid
+        let include_dir = PathBuf::from(value.as_str());
+        if !include_dir.is_dir() {
+            panic!("The specified include directory '{}' in FFMS_INCLUDE_DIR is not valid.", value);
+        }
+
+        // Get the path to the lib.
+        let lib_dir = env::var("FFMS_LIB_DIR").and_then(|lib_dir| {
+            match PathBuf::from(lib_dir) {
+                lib_dir if lib_dir.is_dir() => Ok(lib_dir),
+                _ => Err(VarError::NotPresent)
+            }
+        }).expect("FFMS_LIB_DIR is not set or the specified directory is not valid.");
+
+        // Using dynamic library in Windows remains a problem. We have to copy the DLL into a path...
+        // Problem: If 'FFMS_LIB_DIR' is outside of 'target', it is not considered (https://doc.rust-lang.org/cargo/reference/environment-variables.html).
+        #[cfg(windows)] {
+            let cargo_output_dir = env::var("OUT_DIR").expect("Unable to get OUT_DIR");
+            // We need to add the file in target/{debug|release as it is included in the PATH: https://doc.rust-lang.org/cargo/reference/environment-variables.html#dynamic-library-paths
+            let linkable_dll: PathBuf = [cargo_output_dir.as_ref(), "..", "..", "..", "ffms2.dll"].iter().collect();
+
+            // Copy the file if it does not exists
+            if !linkable_dll.is_file() {
+                let dll_file = lib_dir.as_path().join("ffms2.dll");
+                if !dll_file.is_file() {
+                    panic!("Unable to find the 'ffms2.dll' in 'FFMS_LIB_DIR' ('{}').", lib_dir.display());
+                }
+
+                std::fs::copy(dll_file, linkable_dll).expect("Copying DLL failed");     
+            }
+        }
+
+        // Add the flags for cargo otherwise explicitely added by pkg-config-rs
+        println!("cargo:rustc-link-lib=dylib=ffms2");
+        println!("cargo:rustc-link-search=native={}", lib_dir.to_string_lossy());
+
+        vec![include_dir]
+    }).unwrap_or_else(|_| {
+        let libs = metadeps::probe().expect("Unable to query include paths using pkg-config. Consider setting the environment variable FFMS_INCLUDE_DIR and FFMS_LIB_DIR explicitely.");
+        libs.get("ffms2").unwrap().include_paths.clone()
+    });
 
     let mut builder = bindgen::builder().header("data/ffms.h");
-
     for header in headers {
         builder = builder.clang_arg("-I").clang_arg(header.to_str().unwrap());
     }


### PR DESCRIPTION
Currently, the build script depends on pkg-config. On Microsoft Windows, this imposes unnecessary difficulties. 
With this pull request, the user may manually set the environment variable 'FFMS_INCLUDE_DIR' and 'FFMS_LIB_DIR'. This resembles the optional behavior of other build scripts. On Windows, additional considerations for placing the DLL are employed.