### PR TITLE
Refactor of struct creation macros and removal of custom getters/setters

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ffms2"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Luni-4 <luni-4@hotmail.it>"]
 description = "FFI bindings to ffms2"
 repository = "https://github.com/rust-av/ffms2-rs"

--- a/src/audio.rs
+++ b/src/audio.rs
@@ -55,9 +55,7 @@ create_enum!(
     )
 );
 
-set_struct!(AudioProperties, audio_properties, FFMS_AudioProperties);
-
-default_struct!(
+create_struct!(
     AudioProperties,
     audio_properties,
     FFMS_AudioProperties,
@@ -74,60 +72,6 @@ default_struct!(
     ),
     (0, 0, 0, 0, 0, 0, 0.0, 0.0, 0.0)
 );
-
-set_params!(
-    AudioProperties,
-    audio_properties,
-    (
-        SampleFormat,
-        SampleRate,
-        BitsPerSample,
-        Channels,
-        ChannelLayout,
-        NumSamples,
-        FirstTime,
-        LastTime,
-        LastEndTime,
-    ),
-    (usize, usize, usize, usize, usize, usize, f64, f64, f64),
-    (
-        SampleFormat as i32,
-        SampleRate as i32,
-        BitsPerSample as i32,
-        Channels as i32,
-        ChannelLayout as i64,
-        NumSamples as i64,
-        FirstTime as f64,
-        LastTime as f64,
-        LastEndTime as f64,
-    )
-);
-
-impl AudioProperties {
-    pub fn NumSamples(&self) -> i64 {
-        self.audio_properties.NumSamples
-    }
-
-    pub fn SampleRate(&self) -> i32 {
-        self.audio_properties.SampleRate
-    }
-
-    pub fn Channels(&self) -> i32 {
-        self.audio_properties.Channels
-    }
-
-    pub fn SampleFormat(&self) -> i32 {
-        self.audio_properties.SampleFormat
-    }
-
-    pub fn ChannelLayout(&self) -> i64 {
-        self.audio_properties.ChannelLayout
-    }
-
-    pub fn BitsPerSample(&self) -> i32 {
-        self.audio_properties.BitsPerSample
-    }
-}
 
 pub struct AudioSource {
     audio_source: *mut FFMS_AudioSource,
@@ -175,14 +119,14 @@ impl AudioSource {
     ) -> Result<Vec<T>, Error> {
         let mut error: Error = Default::default();
         let audio_prop = self.GetAudioProperties();
-        let num_samples = audio_prop.NumSamples();
+        let num_samples = audio_prop.NumSamples;
 
         if Start as i64 > (num_samples - 1) || Count as i64 > (num_samples - 1)
         {
             panic!("Requesting samples beyond the stream end");
         }
 
-        let num_channels = audio_prop.Channels();
+        let num_channels = audio_prop.Channels;
         let num_elements = Count * num_channels as usize;
 
         let Buf: Vec<T> = Vec::with_capacity(num_elements);

--- a/src/frame.rs
+++ b/src/frame.rs
@@ -44,14 +44,7 @@ create_struct!(
     frame_info,
     FFMS_FrameInfo,
     (PTS, RepeatPict, KeyFrame, OriginalPTS),
-    (usize, usize, usize, usize),
-    (0, 0, 0, 0),
-    (
-        PTS as i64,
-        RepeatPict as i32,
-        KeyFrame as i32,
-        OriginalPTS as i64
-    )
+    (0, 0, 0, 0)
 );
 
 impl FrameInfo {
@@ -66,9 +59,7 @@ impl FrameInfo {
     }
 }
 
-set_struct!(Frame, frame, FFMS_Frame);
-
-default_struct!(
+create_struct!(
     Frame,
     frame,
     FFMS_Frame,
@@ -133,74 +124,6 @@ default_struct!(
         0,
         0,
         0
-    )
-);
-
-set_params!(
-    Frame,
-    frame,
-    (
-        EncodedWidth,
-        EncodedHeight,
-        EncodedPixelFormat,
-        ScaledWidth,
-        ScaledHeight,
-        ConvertedPixelFormat,
-        KeyFrame,
-        RepeatPict,
-        InterlacedFrame,
-        TopFieldFirst,
-        PictType,
-        ColorSpace,
-        ColorRange,
-        ColorPrimaries,
-        TransferCharateristics,
-        ChromaLocation,
-        HasMasteringDisplayPrimaries,
-        MasteringDisplayPrimariesX,
-        MasteringDisplayPrimariesY,
-        MasteringDisplayWhitePointX,
-        MasteringDisplayWhitePointY,
-        HasMasteringDisplayLuminance,
-        MasteringDisplayMinLuminance,
-        MasteringDisplayMaxLuminance,
-        HasContentLightLevel,
-        ContentLightLevelMax,
-        ContentLightLevelAverage
-    ),
-    (
-        usize, usize, usize, usize, usize, usize, usize, usize, usize, usize,
-        i8, usize, usize, usize, usize, usize, usize, &[f64; 3], &[f64; 3],
-        f64, f64, usize, f64, f64, usize, usize, usize
-    ),
-    (
-        EncodedWidth as i32,
-        EncodedHeight as i32,
-        EncodedPixelFormat as i32,
-        ScaledWidth as i32,
-        ScaledHeight as i32,
-        ConvertedPixelFormat as i32,
-        KeyFrame as i32,
-        RepeatPict as i32,
-        InterlacedFrame as i32,
-        TopFieldFirst as i32,
-        PictType as i8,
-        ColorSpace as i32,
-        ColorRange as i32,
-        ColorPrimaries as i32,
-        TransferCharateristics as i32,
-        ChromaLocation as i32,
-        HasMasteringDisplayPrimaries as i32,
-        *MasteringDisplayPrimariesX as [f64; 3],
-        *MasteringDisplayPrimariesY as [f64; 3],
-        MasteringDisplayWhitePointX as f64,
-        MasteringDisplayWhitePointY as f64,
-        HasMasteringDisplayLuminance as i32,
-        MasteringDisplayMinLuminance as f64,
-        MasteringDisplayMaxLuminance as f64,
-        HasContentLightLevel as i32,
-        ContentLightLevelMax as u32,
-        ContentLightLevelAverage as u32
     )
 );
 

--- a/src/resample.rs
+++ b/src/resample.rs
@@ -60,25 +60,6 @@ create_struct!(
         DitherMethod
     ),
     (
-        usize,
-        &SampleFormat,
-        usize,
-        &MixingCoefficientType,
-        f64,
-        f64,
-        f64,
-        usize,
-        usize,
-        usize,
-        usize,
-        usize,
-        f32,
-        &MatrixEncoding,
-        &ResampleFilterType,
-        usize,
-        &AudioDitherMethod
-    ),
-    (
         0,
         FFMS_SampleFormat::FFMS_FMT_U8,
         0,
@@ -96,25 +77,6 @@ create_struct!(
         FFMS_ResampleFilterType::FFMS_RESAMPLE_FILTER_CUBIC,
         0,
         FFMS_AudioDitherMethod::FFMS_RESAMPLE_DITHER_NONE
-    ),
-    (
-        ChannelLayout as i64,
-        SampleFormat::to_sample_format(SampleFormat),
-        SampleRate as i32,
-        MixingCoefficientType::to_mix_coefficient_type(MixingCoefficientType),
-        CenterMixLevel as f64,
-        SurroundMixLevel as f64,
-        LFEMixLevel as f64,
-        Normalize as i32,
-        ForceResample as i32,
-        ResampleFilterSize as i32,
-        ResamplePhaseShift as i32,
-        LinearInterpolation as i32,
-        CutoffFrequencyRatio as f64,
-        MatrixEncoding::to_matrix_encoding(MatrixedStereoEncoding),
-        ResampleFilterType::to_resample_filter_type(FilterType),
-        KaiserBeta as i32,
-        AudioDitherMethod::to_audio_dither_method(DitherMethod)
     )
 );
 

--- a/src/resample.rs
+++ b/src/resample.rs
@@ -1,4 +1,3 @@
-use crate::audio::MatrixEncoding;
 use crate::*;
 
 create_enum!(

--- a/src/track.rs
+++ b/src/track.rs
@@ -39,9 +39,7 @@ create_struct!(
     track_time_base,
     FFMS_TrackTimeBase,
     (Num, Den),
-    (usize, usize),
-    (0, 0),
-    (Num as i64, Den as i64)
+    (0, 0)
 );
 
 macro_rules! track_error {

--- a/src/utility.rs
+++ b/src/utility.rs
@@ -108,12 +108,29 @@ macro_rules! default_struct {
 }
 
 #[macro_export]
+macro_rules! implement_deref {
+    ($struct:ident, $param:ident, $type:tt) => {
+        impl std::ops::Deref for $struct {
+            type Target = $type;
+
+            fn deref(&self) -> &Self::Target {
+                &self.$param
+            }
+        }
+
+        impl std::ops::DerefMut for $struct {
+            fn deref_mut(&mut self) -> &mut Self::Target {
+                &mut self.$param
+            }
+        }
+    };
+}
+
+#[macro_export]
 macro_rules! create_struct {
     ($struct:ident, $param:ident, $type:tt,
      ($($field_name:ident),*$(,)*),
-     ($($field_type:ty),*$(,)*),
-     ($($field_default_expr:expr),*$(,)*),
-     ($($field_expr:expr),*$(,)*)
+     ($($field_default_expr:expr),*$(,)*)
      ) => {
 
         set_struct!($struct, $param, $type);
@@ -122,28 +139,6 @@ macro_rules! create_struct {
                        ($($field_name,)*),
                        ($($field_default_expr,)*));
 
-        set_params!($struct, $param,
-                   ($($field_name,)*),
-                   ($($field_type,)*),
-                   ($($field_expr,)*));
+        implement_deref!($struct, $param, $type);
     }
-}
-
-#[macro_export]
-macro_rules! set_params {
-    ($struct:ident, $param:ident,
-    ($($field_name:ident),*$(,)*),
-    ($($field_type:ty),*$(,)*),
-    ($($field_expr:expr),*$(,)*))
-    => {
-            impl $struct {
-                paste::item! {
-                    $(
-                        pub fn [<set_ $field_name>](&mut self, $field_name: $field_type) {
-                            self.$param.$field_name = paste::expr! { ($field_expr) }
-                        }
-                    )*
-                }
-            }
-       }
 }

--- a/src/utility.rs
+++ b/src/utility.rs
@@ -19,6 +19,7 @@ macro_rules! create_enum {
 
         impl $enum {
             paste::item! {
+                #[allow(dead_code)]
                 pub(crate) fn [<to_ $func_name>](&self) -> $type {
                     match self {
                         $(

--- a/src/video.rs
+++ b/src/video.rs
@@ -43,9 +43,7 @@ create_enum!(
     (CR_UNSPECIFIED, CR_MPEG, CR_JPEG)
 );
 
-set_struct!(VideoProperties, video_properties, FFMS_VideoProperties);
-
-default_struct!(
+create_struct!(
     VideoProperties,
     video_properties,
     FFMS_VideoProperties,
@@ -86,85 +84,6 @@ default_struct!(
     (
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0.0, 0.0, 0, 0, 0, 0.0, 0,
         [0.0; 3], [0.0; 3], 0.0, 0.0, 0, 0.0, 0.0, 0, 0, 0, 0
-    )
-);
-
-set_params!(
-    VideoProperties,
-    video_properties,
-    (
-        FPSDenominator,
-        FPSNumerator,
-        RFFDenominator,
-        RFFNumerator,
-        NumFrames,
-        SARNum,
-        SARDen,
-        CropTop,
-        CropBottom,
-        CropLeft,
-        CropRight,
-        TopFieldFirst,
-        ColorSpace,
-        ColorRange,
-        FirstTime,
-        LastTime,
-        Rotation,
-        Stereo3DType,
-        Stereo3DFlags,
-        LastEndTime,
-        HasMasteringDisplayPrimaries,
-        MasteringDisplayPrimariesX,
-        MasteringDisplayPrimariesY,
-        MasteringDisplayWhitePointX,
-        MasteringDisplayWhitePointY,
-        HasMasteringDisplayLuminance,
-        MasteringDisplayMinLuminance,
-        MasteringDisplayMaxLuminance,
-        HasContentLightLevel,
-        ContentLightLevelMax,
-        ContentLightLevelAverage,
-        Flip
-    ),
-    (
-        usize, usize, usize, usize, usize, usize, usize, usize, usize, usize,
-        usize, usize, usize, usize, f64, f64, usize, usize, usize, f64, usize,
-        &[f64; 3], &[f64; 3], f64, f64, usize, f64, f64, usize, usize, usize,
-        usize
-    ),
-    (
-        FPSDenominator as i32,
-        FPSNumerator as i32,
-        RFFDenominator as i32,
-        RFFNumerator as i32,
-        NumFrames as i32,
-        SARNum as i32,
-        SARDen as i32,
-        CropTop as i32,
-        CropBottom as i32,
-        CropLeft as i32,
-        CropRight as i32,
-        TopFieldFirst as i32,
-        ColorSpace as i32,
-        ColorRange as i32,
-        FirstTime as f64,
-        LastTime as f64,
-        Rotation as i32,
-        Stereo3DType as i32,
-        Stereo3DFlags as i32,
-        LastEndTime as f64,
-        HasMasteringDisplayPrimaries as i32,
-        *MasteringDisplayPrimariesX as [f64; 3],
-        *MasteringDisplayPrimariesY as [f64; 3],
-        MasteringDisplayWhitePointX as f64,
-        MasteringDisplayWhitePointY as f64,
-        HasMasteringDisplayLuminance as i32,
-        MasteringDisplayMinLuminance as f64,
-        MasteringDisplayMaxLuminance as f64,
-        HasContentLightLevel as i32,
-        ContentLightLevelMax as u32,
-        ContentLightLevelAverage as u32,
-        Flip as i32
     )
 );
 


### PR DESCRIPTION
As the first important step to refactor the source code as mentioned in #16, this pull request removes the custom getters and setters in favor of Deref and DerefMut. This renders the exposed structures as smart pointers with additional convenience functions for creation and updating. By enforcing a consistent usage of `create_struct!` rather than its separate parts all over the crate and removal of the `set_params!` macro, the creation of structs is now unified and simplified.