### PR TITLE
Allow safe multithreading by implementing "Send"

### DIFF
--- a/src/audio.rs
+++ b/src/audio.rs
@@ -193,3 +193,5 @@ impl Drop for AudioSource {
         }
     }
 }
+
+unsafe impl Send for AudioSource {}

--- a/src/index.rs
+++ b/src/index.rs
@@ -182,6 +182,8 @@ impl Drop for Index {
     }
 }
 
+unsafe impl Send for Index {}
+
 pub struct Indexer {
     indexer: *mut FFMS_Indexer,
 }
@@ -322,3 +324,5 @@ impl Indexer {
         }
     }
 }
+
+unsafe impl Send for Indexer {}

--- a/src/track.rs
+++ b/src/track.rs
@@ -118,3 +118,5 @@ impl Track {
         num_frames as usize
     }
 }
+
+unsafe impl Send for Track {}

--- a/src/utility.rs
+++ b/src/utility.rs
@@ -141,5 +141,9 @@ macro_rules! create_struct {
                        ($($field_default_expr,)*));
 
         implement_deref!($struct, $param, $type);
+
+        /// While the underlying pointer might not allow concurrent access from different threads (and is consequently not "Sync"),
+        /// it relies neither on thread-local storage nor thread-specific locks and is therefore safe to send.
+        unsafe impl Send for $struct {}
     }
 }

--- a/src/video.rs
+++ b/src/video.rs
@@ -207,3 +207,5 @@ impl Drop for VideoSource {
         }
     }
 }
+
+unsafe impl Send for VideoSource {}


### PR DESCRIPTION
Currently, the crate is too restrictive in terms of multithreading. While the underlying FFMS2 pointers might not allow concurrent access from different threads (and are consequently not "Sync"), they rely neither on thread-local storage nor thread-specific locks and is therefore safe to send.