### PR TITLE
Use ffi type aliases instead of rust types

### DIFF
--- a/src/index.rs
+++ b/src/index.rs
@@ -4,6 +4,7 @@ use crate::*;
 use ffms2_sys::*;
 
 use std::default::Default;
+use std::ffi::c_char;
 use std::ffi::CString;
 use std::mem;
 use std::os::raw::c_void;
@@ -202,13 +203,13 @@ impl Indexer {
 
     pub fn CodecNameI(&self, Track: usize) -> String {
         let c_ptr = unsafe { FFMS_GetCodecNameI(self.indexer, Track as i32) };
-        let c_str = unsafe { CString::from_raw(c_ptr as *mut i8) };
+        let c_str = unsafe { CString::from_raw(c_ptr as *mut c_char) };
         c_str.to_str().unwrap().to_owned()
     }
 
     pub fn FormatNameI(&self) -> String {
         let c_ptr = unsafe { FFMS_GetFormatNameI(self.indexer) };
-        let c_str = unsafe { CString::from_raw(c_ptr as *mut i8) };
+        let c_str = unsafe { CString::from_raw(c_ptr as *mut c_char) };
         c_str.to_str().unwrap().to_owned()
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,7 @@ pub mod video;
 
 use ffms2_sys::*;
 
+use std::ffi::c_char;
 use std::fmt;
 use std::mem;
 use std::ptr;
@@ -121,7 +122,7 @@ impl Default for Error {
             error,
             buffer: [0; 1024],
         };
-        ffms.error.Buffer = ffms.buffer.as_mut_ptr() as *mut i8;
+        ffms.error.Buffer = ffms.buffer.as_mut_ptr() as *mut c_char;
         ffms.error.BufferSize = mem::size_of_val(&ffms.buffer) as i32;
         ffms
     }


### PR DESCRIPTION
Since ffi type aliases are mapped to different rust types depending on the architecture the lib is built for, using rust types for type casts can cause problem for certain architecture (see [this issue](#33 )). Such problem can be avoided by using the corresponding ffi type aliases instead. The PR replaces rust types by the corresponding ffi type aliases in certain type casts.